### PR TITLE
Add a dummy plugin for the very first `vagrant up`

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,6 +1,21 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 
+# A dummy plugin for DockerRoot to set hostname and network correctly at the very first `vagrant up`
+module VagrantPlugins
+  module GuestLinux
+    class Plugin < Vagrant.plugin("2")
+      guest_capability("linux", "change_host_name") do
+        Cap::ChangeHostName
+      end
+
+      guest_capability("linux", "configure_networks") do
+        Cap::ConfigureNetworks
+      end
+    end
+  end
+end
+
 Vagrant.configure(2) do |config|
   config.vm.define "wocker"
   config.vm.box = "ailispaw/docker-root"


### PR DESCRIPTION
to fix https://github.com/ailispaw/docker-root/issues/2

Just in case, please put a dummy plugin for the very first `vagrant up`.

I know it's ugly, but more convenient than a real plugin.
